### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,30 @@
 language: php
 
-php:
-  - 5.6
-  - 7
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm
-
-sudo: false
+matrix:
+  include:
+    - php: 7.1
+    - php: 7.2
+      env: QA=yes
+    - php: hhvm
+    - php: nightly
+  allow_failures:
+    - php: hhvm
+    - php: nightly
 
 install:
   - composer selfupdate
   - |
-    if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then
-      composer require 'codeclimate/php-test-reporter:*' 'satooshi/php-coveralls:*'
+    if [ "$QA" == "yes" ]; then
+      composer require 'satooshi/php-coveralls:*'
     else
       composer install
     fi
-
-before_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then pecl install runkit; fi
 
 script:
   - composer travis
 
 after_success:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/test-reporter; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/coveralls -v; fi
-
-matrix:
-  allow_failures:
-    - php: hhvm
+  - if [ "$QA" == "yes" ]; then travis_retry php vendor/bin/php-coveralls -v; fi
 
 addons:
   code_climate:

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "psr-4": { "Schnittstabil\\JsonDecodeFile\\": "tests" }
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "duncan3dc/bom-string": "^0.1.0 || ^0.2.0 || ^1.0",
         "kherge/file-manager": "^2.0",
         "seld/jsonlint": "^1.0"
     },
     "require-dev": {
-        "schnittstabil/phpunit-starter": "^6.0 || ^7.0"
+        "schnittstabil/phpunit-starter": "^7.0"
     },
     "extra": {
         "sugared-rim/phpmd": {

--- a/tests/JsonDecodeFileTest.php
+++ b/tests/JsonDecodeFileTest.php
@@ -4,6 +4,7 @@ namespace Schnittstabil\JsonDecodeFile;
 
 use KHerGe\File\Exception\ResourceException;
 use Seld\JsonLint\ParsingException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * schnittstabil/sugared-phpunit may depend on Schnittstabil/JsonDecodeFile,
@@ -14,7 +15,7 @@ use Seld\JsonLint\ParsingException;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class JsonDecodeFileTest extends \PHPUnit\Framework\TestCase
+class JsonDecodeFileTest extends TestCase
 {
     public static function setUpBeforeClass()
     {
@@ -44,18 +45,24 @@ class JsonDecodeFileTest extends \PHPUnit\Framework\TestCase
     public function testJsonDecodeFileShouldThrowOnENOENT()
     {
         $this->expectException(ResourceException::class);
+        $this->expectExceptionMessage('The file "tests/Fixtures/ENOENT.json" could not be opened (r).');
         jsonDecodeFile('tests/Fixtures/ENOENT.json');
     }
 
     public function testJsonDecodeFileShouldThrowOnEPERM()
     {
         $this->expectException(ResourceException::class);
+        $this->expectExceptionMessage('The file "tests/Fixtures/EPERM.json" could not be opened (r).');
         jsonDecodeFile('tests/Fixtures/EPERM.json');
     }
 
     public function testJsonDecodeFileShouldThrowOnInvalidJson()
     {
         $this->expectException(ParsingException::class);
+        $this->expectExceptionMessage('Parse error on line 1:
+
+^
+Expected one of: \'STRING\', \'NUMBER\', \'NULL\', \'TRUE\', \'FALSE\', \'{\', \'[\'');
         jsonDecodeFile('tests/Fixtures/empty.json');
     }
 }


### PR DESCRIPTION
# Changed log
- Let the PHP package require `php-7.1` version at least.
- Add the `expectExceptionMessage` methods for the exception tests.
- Set the proper Travis CI setting is same as the [get package](https://github.com/schnittstabil/get) for the `php-7.1+` version.